### PR TITLE
feat: add keyboard handler and instructions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,7 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           onClick={() => setIsStatsModalOpen(true)}
         />
       </div>
+      <KeyboardInstructions />
       <Grid guesses={guesses} currentGuess={currentGuess} />
       <Keyboard
         onChar={onChar}
@@ -171,6 +172,7 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
         onEnter={onEnter}
         guesses={guesses}
       />
+      <KeyboardHandler onChar={onChar} onDelete={onDelete} onEnter={onEnter} />
       <TranslateModal
         isOpen={isI18nModalOpen}
         handleClose={() => setIsI18nModalOpen(false)}


### PR DESCRIPTION
## Summary
- render keyboard instructions above the board
- mount keyboard handler after the virtual keyboard

## Testing
- `npm run build` (fails: Import in body of module; merge conflict marker)
- `npm test -- --watchAll=false` (fails: identifier 'ORTHOGRAPHY_LETTERS' has already been declared)


------
https://chatgpt.com/codex/tasks/task_e_689137e3adb48324b05cd196bc379839